### PR TITLE
Closed #43, 調整 Order#show

### DIFF
--- a/assets/scss/base/_shared.scss
+++ b/assets/scss/base/_shared.scss
@@ -143,7 +143,7 @@ a {
   .main-table {
 
     .image {
-      max-width: 160px;
+      max-width: 200px;
     }
   }
 }

--- a/lib/zazaar_web/templates/order/show.html.eex
+++ b/lib/zazaar_web/templates/order/show.html.eex
@@ -92,9 +92,8 @@
       <table class="table main-table is-striped is-hoverable">
         <thead class="main-table__header">
           <tr>
-            <th width="25%"><%= gettext "得標時間" %></th>
             <th width="25%"><%= gettext "Snapshot" %></th>
-            <th width="35%"><%= gettext "Product Name" %></th>
+            <th width="60%"><%= gettext "Product Name" %></th>
             <th width="15%"><%= gettext "Amount" %></th>
           </tr>
         </thead>
@@ -103,9 +102,8 @@
 
           <%= for _x <- 1..3 do %>
             <tr>
-              <td>2018年12月26日下午3:33</td>
               <td>
-                <figure class="image is-thumbnail"> <!-- Modal Trigger -->
+                <figure class="image is-thumbnail">
                   <img class="merch-snapshot" src="https://bulma.io/images/placeholders/640x480.png">
                 </figure>
               </td>
@@ -114,10 +112,12 @@
             </tr>
           <% end %>
 
+          <!-- Start: Edit Mode -->
+
+          <!-- Edit exist item-->
           <tr>
-            <td>2018年12月26日下午3:33</td>
             <td>
-              <figure class="image is-thumbnail"> <!-- Modal Trigger -->
+              <figure class="image is-thumbnail">
                 <img class="merch-snapshot" src="https://bulma.io/images/placeholders/640x480.png">
               </figure>
             </td>
@@ -133,14 +133,20 @@
             </td>
           </tr>
 
-        </tbody>
+          <!-- Add new item-->
+          <tr>
+            <td colspan="3">
+              <a class="button is-block is-text has-text-primary">新增項目</a>
+            </td>
+          </tr>
 
-        <tbody class="main-table__body" id="items-table-body">
+          <!-- End: Edit Mode -->
+
         </tbody>
 
         <tfoot>
           <tr>
-            <td colspan="3" class="has-text-right has-text-grey-light"><%= gettext "Amount Due (NTD)" %></td>
+            <td colspan="2" class="has-text-right has-text-grey-light"><%= gettext "Amount Due (NTD)" %></td>
             <td >3000</td>
           </tr>
         </tfoot>


### PR DESCRIPTION
#43 

![2019-02-17 15 42 34](https://user-images.githubusercontent.com/10168831/52909992-ff086180-32cb-11e9-97e0-19743bbca1ff.png)

這邊加上「新增項目」的按鈕（只有在編輯模式才會出現）
點擊後，在按鈕上方插入新的 `tr` 讓使用者可以直接編輯

剛剛想到，因為金額也是可以編輯的
所以使用者其實可以直接把金額歸零來取消某個項目，而不需透過負值來調整金額
我的理解有錯誤嗎？ @yuchunc 